### PR TITLE
Make usernames unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ RESTful API for creating and accessing information on volleyball events
 **GET** /players
 + Returns an array with JSON objects representing all players 
   - Status Code 200: Successful retrieval of all players
+  - Status Code 422: Failed to add player because username was a duplicate
     
 **GET** /players/id
 + Returns the Player object with the given id

--- a/src/main/java/com/ismadoro/controllers/PlayerController.java
+++ b/src/main/java/com/ismadoro/controllers/PlayerController.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ismadoro.entities.Player;
+import com.ismadoro.exceptions.DuplicateResourceException;
 import com.ismadoro.exceptions.ResourceNotFound;
 import com.ismadoro.services.PlayerService;
 import io.javalin.http.Handler;
@@ -19,12 +20,17 @@ public class PlayerController {
     }
 
     public Handler addNewPlayer = ctx -> {
-        Gson gson = new Gson();
-        Player player = gson.fromJson(ctx.body(), Player.class);
-        player = this.playerService.addPlayer(player);
-        String playerJson = gson.toJson(player);
-        ctx.result(playerJson);
-        ctx.status(201);
+        try {
+            Gson gson = new Gson();
+            Player player = gson.fromJson(ctx.body(), Player.class);
+            player = this.playerService.addPlayer(player);
+            String playerJson = gson.toJson(player);
+            ctx.result(playerJson);
+            ctx.status(201);
+        } catch (DuplicateResourceException duplicateResourceException) {
+            ctx.result(duplicateResourceException.message);
+            ctx.status(422);
+        }
     };
 
     public Handler getAllPlayers = ctx -> {

--- a/src/main/java/com/ismadoro/controllers/PlayerController.java
+++ b/src/main/java/com/ismadoro/controllers/PlayerController.java
@@ -80,6 +80,9 @@ public class PlayerController {
         } catch (ResourceNotFound resourceNotFound) {
             ctx.result(resourceNotFound.message);
             ctx.status(404);
+        } catch (DuplicateResourceException duplicateResourceException) {
+            ctx.result(duplicateResourceException.message);
+            ctx.status(422);
         }
     };
 

--- a/src/main/java/com/ismadoro/daos/PlayerDaoLocal.java
+++ b/src/main/java/com/ismadoro/daos/PlayerDaoLocal.java
@@ -1,6 +1,7 @@
 package com.ismadoro.daos;
 
 import com.ismadoro.entities.Player;
+import com.ismadoro.exceptions.DuplicateResourceException;
 import com.ismadoro.exceptions.ResourceNotFound;
 
 import java.util.ArrayList;
@@ -11,10 +12,19 @@ import java.util.Map;
 public class PlayerDaoLocal implements PlayerDao{
 
     private static final Map<Integer, Player> map = new HashMap<>();
+    private static final Map<String, Integer> usedUsernames = new HashMap<>();
     private static int idCounter = 1;
 
     @Override
     public Player addPlayer(Player player) {
+        //Check that no duplicate usernames have been added
+        Integer usernameOwnedBy = usedUsernames.get(player.getUsername());
+        if (usernameOwnedBy != null) {
+            throw new DuplicateResourceException("A player with that username already exists");
+        } else {
+            usedUsernames.put(player.getUsername(), player.getPlayerId());
+        }
+
         Integer id = idCounter++;
         player.setPlayerId(id);
         map.put(id, player);

--- a/src/main/java/com/ismadoro/daos/PlayerDaoLocal.java
+++ b/src/main/java/com/ismadoro/daos/PlayerDaoLocal.java
@@ -22,7 +22,7 @@ public class PlayerDaoLocal implements PlayerDao{
         if (usernameOwnedBy != null) {
             throw new DuplicateResourceException("A player with that username already exists");
         } else {
-            usedUsernames.put(player.getUsername(), player.getPlayerId());
+            usedUsernames.put(player.getUsername(), idCounter);
         }
 
         Integer id = idCounter++;
@@ -56,8 +56,16 @@ public class PlayerDaoLocal implements PlayerDao{
         if (map.get(id) == null) {
             throw new ResourceNotFound("Resource with given ID not found");
         }
-        map.put(id, player);
-        return player;
+
+        String username = player.getUsername();
+        //Check that if the username has been changed it's not already taken
+        if (usedUsernames.get(username) == null || usedUsernames.get(username) == player.getPlayerId()) {
+            usedUsernames.put(username, player.getPlayerId());
+            map.put(id, player);
+            return player;
+        } else {
+            throw new DuplicateResourceException("That username is already taken");
+        }
     }
 
     @Override

--- a/src/main/java/com/ismadoro/exceptions/DuplicateResourceException.java
+++ b/src/main/java/com/ismadoro/exceptions/DuplicateResourceException.java
@@ -1,0 +1,8 @@
+package com.ismadoro.exceptions;
+
+public class DuplicateResourceException extends RuntimeException {
+    public String message;
+    public DuplicateResourceException(String message) {
+        this.message = message;
+    }
+}

--- a/src/test/java/com/ismadoro/daos/PlayerDaoTests.java
+++ b/src/test/java/com/ismadoro/daos/PlayerDaoTests.java
@@ -1,6 +1,7 @@
 package com.ismadoro.daos;
 
 import com.ismadoro.entities.Player;
+import com.ismadoro.exceptions.DuplicateResourceException;
 import com.ismadoro.exceptions.ResourceNotFound;
 import org.testng.Assert;
 
@@ -26,6 +27,16 @@ public class PlayerDaoTests {
         playerDao.addPlayer(testPlayer2);
         Assert.assertNotEquals(testPlayer2.getPlayerId(), 0);
         Assert.assertNotEquals(testPlayer.getPlayerId(), testPlayer2.getPlayerId());
+    }
+
+    @Test(priority = 2)
+    void testAddDuplicatePlayer() {
+        try {
+            playerDao.addPlayer(testPlayer2);
+            Assert.fail();
+        } catch (DuplicateResourceException duplicateResourceException) {
+            //Succeed
+        }
     }
 
     @Test(priority = 2)

--- a/src/test/java/com/ismadoro/daos/PlayerDaoTests.java
+++ b/src/test/java/com/ismadoro/daos/PlayerDaoTests.java
@@ -83,6 +83,17 @@ public class PlayerDaoTests {
         }
     }
 
+    @Test(priority = 4)
+    void testUpdateToExistingUsername() {
+        testPlayer.setUsername(testPlayer2.getUsername());
+        try {
+            playerDao.updatePlayer(testPlayer);
+            Assert.fail();
+        } catch (DuplicateResourceException duplicateResourceException) {
+            //Succeed
+        }
+    }
+
     @Test(priority = 5)
     void testDeletePlayer() {
         boolean deleted = playerDao.deletePlayer(testPlayer.getPlayerId());


### PR DESCRIPTION
I added some testing to the player DAOs and functionality to the PlayerDaoLocal class that ensures all usernames are unique.  Players can't be added if their username is already taken or updated to an already existing username. 

I did regression testing before this, running all player DAO and Services tests, as well as running all Postman tests again to check the endpoints.